### PR TITLE
Add npm version shield to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Krewcumber
 
+[![krewcumber npm](https://img.shields.io/npm/v/krewcumber.svg)]()
+
 Designed to work with [Chimp](https://chimp.readme.io/). Krewcumber is a library that makes use of
 [WebdriverIO](http://webdriver.io/) and [Cucumber](https://cucumber.io/) to make writing user
 acceptance tests easier.


### PR DESCRIPTION
The README needs a little extra flair.

There's more badges available at [shields.io](http://shields.io/), but this is currently the only one that applies to this project.

I'd like to get travis and codecov shields added in the future.