### PR TITLE
Dropdown contains values

### DIFF
--- a/example/features/form/select.feature
+++ b/example/features/form/select.feature
@@ -12,3 +12,6 @@ Feature: Manipulating selects
   Scenario: We want to check whether a multiselect has a option
     Then the "Tags" multiselect should contain the options: "Events, Promos"
      And the "Tags" multiselect should not contain the option: "News"
+
+  Scenario: We want to select a dropdown option
+    When I select the "Red" option from the "Color" dropdown

--- a/example/features/form/select.feature
+++ b/example/features/form/select.feature
@@ -6,8 +6,8 @@ Feature: Manipulating selects
     Given I am at "http://localhost:8080/search.html"
 
   Scenario: We want to check whether a dropdown has a option
-    Then the "Colors" dropdown should contain the options: "Red, Yellow, Blue"
-     And the "Colors" dropdown should not contain the option: "Black"
+    Then the "Color" dropdown should contain the options: "Red, Yellow, Blue"
+     And the "Color" dropdown should not contain the option: "Black"
 
   Scenario: We want to check whether a multiselect has a option
     Then the "Tags" multiselect should contain the options: "Events, Promos"

--- a/example/features/form/select.feature
+++ b/example/features/form/select.feature
@@ -1,0 +1,14 @@
+Feature: Manipulating selects
+
+  We should be able to manipulate selects on a page.
+
+  Background:
+    Given I am at "http://localhost:8080/search.html"
+
+  Scenario: We want to check whether a dropdown has a option
+    Then the "Colors" dropdown should contain the options: "Red, Yellow, Blue"
+     And the "Colors" dropdown should not contain the option: "Black"
+
+  Scenario: We want to check whether a multiselect has a option
+    Then the "Tags" multiselect should contain the options: "Events, Promos"
+     And the "Tags" multiselect should not contain the option: "News"

--- a/example/features/form/select.feature
+++ b/example/features/form/select.feature
@@ -10,8 +10,17 @@ Feature: Manipulating selects
      And the "Color" dropdown should not contain the option: "Black"
 
   Scenario: We want to check whether a multiselect has a option
-    Then the "Tags" multiselect should contain the options: "Events, Promos"
+    Then the "Tags" multiselect should contain the options: "Events, Promos, Places, Featured"
      And the "Tags" multiselect should not contain the option: "News"
+     And the "Tags" multiselect should not contain the options: "News, Local"
 
   Scenario: We want to select a dropdown option
     When I select the "Red" option from the "Color" dropdown
+    Then the "Color" dropdown should have the "Red" option selected
+     And the "Color" dropdown should not have the "Select color" option selected
+
+  Scenario: We want to select multiselect options
+    When I select the "Events, Promos" options from the "Tags" multiselect
+    Then the "Tags" multiselect should have the "Events, Promos" options selected
+     And the "Tags" multiselect should not have the "Places" option selected
+     And the "Tags" multiselect should not have the "Places, Featured" options selected

--- a/example/test/search.html
+++ b/example/test/search.html
@@ -59,7 +59,7 @@
     method="GET"
   >
     <label>
-      Colors
+      Color
       <select
         name="color"
       >

--- a/example/test/search.html
+++ b/example/test/search.html
@@ -53,5 +53,35 @@
       value="Register"
     >
   </form>
+
+  <form
+    action="/results.html"
+    method="GET"
+  >
+    <label>
+      Colors
+      <select
+        name="color"
+      >
+        <option selected disabled>Select color</option>
+        <option value="red">Red</option>
+        <option value="yellow">Yellow</option>
+        <option value="blue">Blue</option>
+      </select>
+    </label>
+    <label>
+      Tags
+      <select
+        name="tags"
+      >
+        <option value="events">Events</option>
+        <option value="promos">Promos</option>
+      </select>
+    </label>
+    <input
+      type="submit"
+      value="Create"
+    >
+  </form>
 </body>
 </html>

--- a/example/test/search.html
+++ b/example/test/search.html
@@ -73,6 +73,7 @@
       Tags
       <select
         name="tags"
+        multiple
       >
         <option value="events">Events</option>
         <option value="promos">Promos</option>

--- a/example/test/search.html
+++ b/example/test/search.html
@@ -77,6 +77,8 @@
       >
         <option value="events">Events</option>
         <option value="promos">Promos</option>
+        <option value="featured">Featured</option>
+        <option value="places">Places</option>
       </select>
     </label>
     <input

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "krewcumber",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A user acceptance test library powered by Cucumber and WebdriverIO",
   "main": "step_definitions/index.js",
   "dependencies": {

--- a/step_definitions/lib/form/index.js
+++ b/step_definitions/lib/form/index.js
@@ -1,4 +1,5 @@
 module.exports = {
   form: require('./form'),
   input: require('./input'),
+  select: require('./select'),
 };

--- a/step_definitions/lib/form/select/index.js
+++ b/step_definitions/lib/form/select/index.js
@@ -1,0 +1,47 @@
+var expect = require('chai').expect;
+var webdriverIOHelpers = require('../../../helpers/webdriverio');
+
+var getElement = webdriverIOHelpers.getElement;
+
+module.exports = {
+  assertSelectContainsOptions: assertSelectContainsOptions,
+};
+
+/**
+ * Gets an select based on a reference string
+ * @param  {WebdriverIO} browser   Instance of web driver
+ * @param  {String}      reference The select reference, could be name > placeholder > label
+ * @return {String}      element   The select element
+ */
+function getSelectElement (browser, reference) {
+  var selectElement = getElement(browser, reference);
+  if (selectElement) {
+    return selectElement;
+  }
+
+  var selectElementByName = getElement(browser, 'select[name="' + reference + '"]');
+  if (selectElementByName) {
+    return selectElementByName;
+  }
+
+  var labelElementByText = getElement(browser, 'label*=' + reference);
+  if (labelElementByText) {
+    return getElement(labelElementByText, 'select');
+  }
+}
+
+function assertSelectContainsOptions (browser, selectReference, options, isRequired) {
+  var expectedValues = options.split(/,\s*/g);
+  var selectElement = getSelectElement(browser, selectReference);
+  var actualValues = selectElement.elements('option').value.map(function (optionElement) {
+    return optionElement.getText();
+  });
+
+  console.log(actualValues);
+
+  if (isRequired) {
+    return expect(actualValues).to.include.members(expectedValues);
+  }
+
+  return expect(actualValues).to.not.include.members(expectedValues);
+}

--- a/step_definitions/lib/form/select/index.js
+++ b/step_definitions/lib/form/select/index.js
@@ -5,6 +5,7 @@ var getElement = webdriverIOHelpers.getElement;
 
 module.exports = {
   assertSelectContainsOptions: assertSelectContainsOptions,
+  setSelectValue: setSelectValue,
 };
 
 /**
@@ -49,4 +50,15 @@ function assertSelectContainsOptions (browser, reference, options, isRequired) {
   }
 
   return expect(actualValues).to.not.include.members(expectedValues);
+}
+
+/**
+ * Sets the select elements value based on visible text
+ * @param  {WebdriverIO} browser   Instance of web driver
+ * @param  {String}      reference The select reference, could be name > placeholder > label
+ * @param  {String}      text      The text to select by
+ */
+function setSelectValue (browser, reference, text) {
+  var selectElement = getSelectElement(browser, reference);
+  return selectElement.selectByVisibleText(text);
 }

--- a/step_definitions/lib/form/select/index.js
+++ b/step_definitions/lib/form/select/index.js
@@ -30,14 +30,19 @@ function getSelectElement (browser, reference) {
   }
 }
 
-function assertSelectContainsOptions (browser, selectReference, options, isRequired) {
+/**
+ * Checks the whether the select element contains a value or not
+ * @param  {WebdriverIO} browser    Instance of web driver
+ * @param  {String}      reference  The select reference, could be name > placeholder > label
+ * @param  {[String]}    options    The expected options
+ * @param  {Boolean}     isRequired Whether the options are required or not
+ */
+function assertSelectContainsOptions (browser, reference, options, isRequired) {
   var expectedValues = options.split(/,\s*/g);
-  var selectElement = getSelectElement(browser, selectReference);
+  var selectElement = getSelectElement(browser, reference);
   var actualValues = selectElement.elements('option').value.map(function (optionElement) {
     return optionElement.getText();
   });
-
-  console.log(actualValues);
 
   if (isRequired) {
     return expect(actualValues).to.include.members(expectedValues);

--- a/step_definitions/lib/form/select/index.js
+++ b/step_definitions/lib/form/select/index.js
@@ -3,9 +3,13 @@ var webdriverIOHelpers = require('../../../helpers/webdriverio');
 
 var getElement = webdriverIOHelpers.getElement;
 
+var COMMA_SEPARATION = /,\s*/g;
+
 module.exports = {
   assertSelectContainsOptions: assertSelectContainsOptions,
+  assertSelectedValue: assertSelectedValue,
   setSelectValue: setSelectValue,
+  setMultiSelectValue: setMultiSelectValue,
 };
 
 /**
@@ -53,6 +57,27 @@ function assertSelectContainsOptions (browser, reference, options, isRequired) {
 }
 
 /**
+ * Checks the whether the select element has an option selected or not
+ * @param  {WebdriverIO} browser    Instance of web driver
+ * @param  {String}      reference  The select reference, could be name > placeholder > label
+ * @param  {String}      text       The selected option's text
+ * @param  {Boolean}     isSelected Whether the options are selected or not
+ */
+function assertSelectedValue (browser, reference, text, isSelected) {
+  var expectedValues = text.split(COMMA_SEPARATION);
+  var selectElement = getSelectElement(browser, reference);
+  var actualValues = selectElement.elements('option:checked').value.map(function (optionElement) {
+    return optionElement.getText();
+  });
+
+  if (isSelected) {
+    return expect(actualValues).to.include.members(expectedValues);
+  }
+
+  return expect(actualValues).to.not.include.members(expectedValues);
+}
+
+/**
  * Sets the select elements value based on visible text
  * @param  {WebdriverIO} browser   Instance of web driver
  * @param  {String}      reference The select reference, could be name > placeholder > label
@@ -61,4 +86,19 @@ function assertSelectContainsOptions (browser, reference, options, isRequired) {
 function setSelectValue (browser, reference, text) {
   var selectElement = getSelectElement(browser, reference);
   return selectElement.selectByVisibleText(text);
+}
+
+/**
+ * Sets the multiselect elements value based on visible text
+ * @param  {WebdriverIO} browser   Instance of web driver
+ * @param  {String}      reference The select reference, could be name > placeholder > label
+ * @param  {String}      text      The text to select by
+ */
+function setMultiSelectValue (browser, reference, text) {
+  var selectElement = getSelectElement(browser, reference);
+  var targetValues = text.split(COMMA_SEPARATION);
+
+  targetValues.forEach(function (text) {
+    return selectElement.selectByVisibleText(text);
+  });
 }

--- a/step_definitions/then.js
+++ b/step_definitions/then.js
@@ -14,4 +14,8 @@ module.exports = function () {
   this.Then(/^the "([^"]*)" field should( not)? be required$/, function (inputReference, isNotRequired) {
     return form.input.assertInputRequired(browser, inputReference, !isNotRequired);
   });
+
+  this.Then(/^the "([^"]*)" (?:dropdown|multiselect) should( not)? contain the options?: "([^"]*)"$/, function (selectReference, isNotRequired, options) {
+    return form.select.assertSelectContainsOptions(browser, selectReference, options, !isNotRequired);
+  });
 }

--- a/step_definitions/then.js
+++ b/step_definitions/then.js
@@ -18,4 +18,8 @@ module.exports = function () {
   this.Then(/^the "([^"]*)" (?:dropdown|multiselect) should( not)? contain the options?: "([^"]*)"$/, function (selectReference, isNotRequired, options) {
     return form.select.assertSelectContainsOptions(browser, selectReference, options, !isNotRequired);
   });
+
+  this.Then(/^the "([^"]*)" (?:dropdown|multiselect) should( not)? have the "([^"]*)" options? selected$/, function (selectReference, isNotSelected, value) {
+    return form.select.assertSelectedValue(browser, selectReference, value, !isNotSelected);
+  });
 }

--- a/step_definitions/when.js
+++ b/step_definitions/when.js
@@ -23,4 +23,8 @@ module.exports = function () {
   this.When(/^I click the "([^"]*)"$/, function (selector) {
     return interaction.clickElement(browser, selector);
   });
+
+  this.When(/^I select the "([^"]*)" option from the "([^"]*)" dropdown$/, function (value, selectReference) {
+    return form.select.setSelectValue(browser, selectReference, value);
+  });
 }

--- a/step_definitions/when.js
+++ b/step_definitions/when.js
@@ -27,4 +27,8 @@ module.exports = function () {
   this.When(/^I select the "([^"]*)" option from the "([^"]*)" dropdown$/, function (value, selectReference) {
     return form.select.setSelectValue(browser, selectReference, value);
   });
+
+  this.When(/^I select the "([^"]*)" options from the "([^"]*)" multiselect$/, function (value, selectReference) {
+    return form.select.setMultiSelectValue(browser, selectReference, value);
+  });
 }


### PR DESCRIPTION
Adds a step to assert whether a select element contains options or not.

Should work for both dropdowns and multiselects.

It doesn't care about the actual `value` attributes, and instead is referring to the display values.