### PR TITLE
Fix assert url path

### DIFF
--- a/example/features/navigation/location.feature
+++ b/example/features/navigation/location.feature
@@ -9,3 +9,7 @@ Feature: Navigating via browser location
   Scenario: We want to test navigating via setting a relative URL.
     When I am at "/"
     Then I should be at "http://localhost:8080/"
+  
+  Scenario: We want to test asserting a relativeURL.
+    When I am at "/"
+    Then I should be at "/"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "krewcumber",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A user acceptance test library powered by Cucumber and WebdriverIO",
   "main": "step_definitions/index.js",
   "dependencies": {

--- a/step_definitions/lib/navigation/location/index.js
+++ b/step_definitions/lib/navigation/location/index.js
@@ -28,7 +28,9 @@ function setBrowserLocation (browser, uri) {
  * @param  {String}      targetUrl The target url
  */
 function assertAtLocation (browser, targetUrl) {
-  expect(browser.getUrl()).to.equal(targetUrl);
+  var actualUrl = browser.getUrl();
+  var resolvedUrl = resolveUrl(actualUrl, targetUrl);
+  expect(actualUrl).to.equal(resolvedUrl);
 }
 
 /**


### PR DESCRIPTION
Resolves the bug where relative paths would not be resolved based on the the webdriver's `baseUrl` property.

Fixes #8.